### PR TITLE
state file parsing

### DIFF
--- a/src/lib/NavBar.svelte
+++ b/src/lib/NavBar.svelte
@@ -3,8 +3,11 @@
         <a class="btn btn-ghost normal-case text-xl" href="/">Karen-UI</a>
     </div>
     <div class="flex-none">
-        <a href="/data-upload">
-            <button class="btn btn-square btn-ghost mr-2" href="/data-upload">
+        <a href="/data-upload/karen-file">
+            <button
+                class="btn btn-square btn-ghost mr-2"
+                href="/data-upload/karen-file"
+            >
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
@@ -19,6 +22,22 @@
                         d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
                     />
                 </svg>
+            </button>
+        </a>
+    </div>
+    <div class="flex-none">
+        <a href="/data-upload/state-file">
+            <button
+                class="btn btn-square btn-ghost mr-2"
+                href="/data-upload/state-file"
+            >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="#000" stroke-linecap="round" stroke-linejoin="round" fill="#000" fill-rule="evenodd">
+                <path 
+                    d="M23 8l-2-2c-1-2-3-4-5-4h-1c-1-1-3-2-4-2-2 0-3 1-5 2-1 1-1 2-1 3-3 0-5 3-5 5 0 3 2 6 6 6h0v2c1 0 1 1 2 1v2c0 1 1 2 1 2 1 1 1 1 2 1h2c1 0 1 0 2-1 0 0 1-1 1-2v-2c1 0 1-1 2-1v-2h1c3 0 5-2 5-5 0-1 0-3-1-3zm-7 9h-1 0-2v4 1h-2v-1-4H9h0-1v-1l4-5 4 5v1z" 
+                    stroke="none" 
+                    fill="#fff" 
+                    fill-rule="nonzero"/>
+            </svg> 
             </button>
         </a>
     </div>

--- a/src/lib/api/preprocessor.ts
+++ b/src/lib/api/preprocessor.ts
@@ -1,0 +1,20 @@
+const url = "http://localhost:3000"
+
+
+export async function fetchParsedStateFile(stateFile:string): Promise<string> {
+    const encoder = new TextEncoder();
+    // Encode the JSON string to a Uint8Array
+    const jsonBytes = encoder.encode(stateFile);
+    const response = await fetch(
+        url + "/",
+        {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+                },
+            body: jsonBytes
+        }
+        )
+    return await response.json()
+}

--- a/src/routes/data-upload/karen-file/+page.svelte
+++ b/src/routes/data-upload/karen-file/+page.svelte
@@ -1,10 +1,10 @@
-<script lang="ts">
+ <script lang="ts">
     import { error } from "@sveltejs/kit";
     import {
         saveFile,
         fetchNamespaces,
         dropNamespace as storeDropNamespace,
-    } from "../../stores/nodes/nodes";
+    } from "../../../stores/nodes/nodes";
 
     let files: FileList | undefined = undefined;
     let fetchNamespacePromise = fetchNamespaces();
@@ -24,6 +24,7 @@
                     if (customNamespaceName !== ""){
                         namespace = customNamespaceName
                     }
+                    console.log(text)
                     await saveFile(namespace, text);
                     refetchNamespaces();
                 } catch (error) {

--- a/src/routes/data-upload/state-file/+page.svelte
+++ b/src/routes/data-upload/state-file/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+    import { fetchParsedStateFile } from "$lib/api/preprocessor";
+    import {
+        saveFile,
+    } from "../../../stores/nodes/nodes";
+
+    let files: FileList | undefined = undefined;
+    let customNamespaceName = "";
+
+    async function uploadFile() {
+        if (files !== undefined && files[0]) {
+            const text = await files[0].text();
+            const filename = files[0].name;
+
+            try {
+                // TODO: remove this debug log
+                console.log(text);
+                
+                // Post the state file to preprocessor and wait for karen-intermediate format
+                let parsedFileJsonObject = await fetchParsedStateFile(text);
+                let namespace = filename;
+                if (customNamespaceName !== "") {
+                    namespace = customNamespaceName;
+                }
+
+                // TODO: remove this debug log
+                console.log(parsedFileJsonObject);
+    
+                let parsedFileJsonString = JSON.stringify(parsedFileJsonObject)
+                await saveFile(namespace, parsedFileJsonString);
+
+            } catch (error) {
+                console.error(error);
+            }
+        }
+    }
+</script>
+
+<template>
+    <input
+        type="file"
+        accept=".json"
+        bind:files
+        class="file-input file-input-bordered ml-4 mt-4"
+    />
+
+    <div class="form-control mt-4 ml-4">
+        <div class="input-group">
+            <input
+                type="text"
+                placeholder="Filname..."
+                class="input input-bordered"
+                bind:value={customNamespaceName}
+            />
+            <div
+                data-tip="If no name is provided the filename will be used"
+                class="tooltip"
+            >
+                <button class="btn" on:click={uploadFile}>Parse</button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/stores/nodes/nodes.ts
+++ b/src/stores/nodes/nodes.ts
@@ -112,7 +112,6 @@ function getDependentNodes(nodeTableName: string, nodeAddress: string) {
 
 export async function saveFile(namespace: string, text: string): Promise<boolean> {
     const jsonString = text.trim()
-    var nodes = JSON.parse(jsonString)
     try {
         localStorage.setItem(namespace, text);
     } catch (error) {


### PR DESCRIPTION
**1. What this MR does / why we need it:**

- Currently the state files need to be manually preprocessed by the karen-preprocessor
- The User has a state file generated by `terraform show`, which should be automatically parsed somehow
- This approach uses the karen-preprocessor http interface to post the state file and retrieve the karen-intermediate format 

**2. Make sure that you've checked the boxes below before you submit MR:**

- [ ] I have run `npm run test` locally and there is no error.
- [ ] I have added documentation .
- [ ] I have implemented tests for my feature.
- [ ] no conflict with main branch.


**3. Which issue this PR fixes (optional)**

![PR-statefile-parse](https://github.com/bfrn/karen-ui/assets/24325735/a0174405-fa1e-4f29-ab66-d04255960fa3)

